### PR TITLE
Fix Pydantic list default

### DIFF
--- a/app/models_pydantic/chat.py
+++ b/app/models_pydantic/chat.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import List, Optional, Dict, Any # Any foi usado para page
 
 class ChatRequest(BaseModel):
@@ -14,5 +14,5 @@ class SourceDocument(BaseModel):
 
 class ChatResponse(BaseModel):
     answer: Optional[str] = None
-    source_documents: List[SourceDocument] = []
+    source_documents: List[SourceDocument] = Field(default_factory=list)
     error: Optional[str] = None


### PR DESCRIPTION
## Summary
- fix mutable default for `ChatResponse.source_documents`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683f4f29ffdc832dafe86e26a483d4ed