### PR TITLE
Fix router prefix

### DIFF
--- a/app/api/v1/endpoints/router.py
+++ b/app/api/v1/endpoints/router.py
@@ -2,4 +2,4 @@ from fastapi import APIRouter
 from app.api.v1.endpoints import chat
 
 api_router = APIRouter()
-api_router.include_router(chat.router, prefix="/chat/", tags=["Chat RAG"]) # Tag alterada
+api_router.include_router(chat.router, prefix="/chat", tags=["Chat RAG"]) # Tag alterada


### PR DESCRIPTION
## Summary
- fix prefix for chat router

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 - <<'PY'
import sys, types
langchain = types.ModuleType('langchain'); langchain.chains = types.ModuleType('langchain.chains'); sys.modules['langchain']=langchain; sys.modules['langchain.chains']=langchain.chains
langchain.chains.RetrievalQA = type('RetrievalQA',(),{'from_chain_type':staticmethod(lambda **kw: type('QA',(),{'invoke':lambda self,*a,**k:{"result":"","source_documents":[]}})())})
langchain.prompts=types.ModuleType('langchain.prompts'); sys.modules['langchain.prompts']=langchain.prompts; langchain.prompts.PromptTemplate=type('PromptTemplate',(),{})
import types as t
lc_comm=t.ModuleType('langchain_community'); lc_comm.vectorstores=t.ModuleType('langchain_community.vectorstores')
class FAISS:
    @staticmethod
    def load_local(*a,**k):
        class VS:
            def as_retriever(self,**kw):
                return None
        return VS()
lc_comm.vectorstores.FAISS=FAISS
sys.modules['langchain_community']=lc_comm; sys.modules['langchain_community.vectorstores']=lc_comm.vectorstores
lc_hf=t.ModuleType('langchain_huggingface'); lc_hf.HuggingFaceEmbeddings=type('HuggingFaceEmbeddings',(),{})
sys.modules['langchain_huggingface']=lc_hf
lc_openai=t.ModuleType('langchain_openai'); lc_openai.ChatOpenAI=type('ChatOpenAI',(),{})
sys.modules['langchain_openai']=lc_openai
from app.main import app
print('routes:', [r.path for r in app.routes])
PY

------
https://chatgpt.com/codex/tasks/task_e_683f50ca5488832d9ba98b12e76dc7d9