### PR TITLE
Add configurable CORS origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # ia_multi_author_backend
+
+This project exposes a FastAPI application for a Retrieval-Augmented Generation (RAG) service.
+
+## Configuration
+
+Settings are loaded from environment variables using `pydantic-settings`.  The most relevant variables are:
+
+- `OPENROUTER_API_KEY` – API key used by the RAG service.
+- `EMBEDDING_MODEL_NAME` – name of the embedding model.
+- `LLM_MODEL_NAME` – name of the language model.
+- `FAISS_INDEX_PATH` – directory containing the FAISS index.
+- `ALLOWED_ORIGINS` – comma-separated list of origins allowed by CORS (e.g. `"http://localhost:3000,https://example.com"`).
+
+Create a `.env` file or export the variables before starting the application.

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -5,8 +5,10 @@ class Settings(BaseSettings):
     EMBEDDING_MODEL_NAME: str = "sentence-transformers/paraphrase-multilingual-mpnet-base-v2"
     LLM_MODEL_NAME: str = "deepseek/deepseek-r1:free" # Comece com um modelo confiável
     FAISS_INDEX_PATH: str = "faiss_index_multi_author"
+    ALLOWED_ORIGINS: str = "http://localhost:3000"
 
     # Para carregar do arquivo .env
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding='utf-8', extra='ignore')
+
 
 settings = Settings()

--- a/app/main.py
+++ b/app/main.py
@@ -36,15 +36,8 @@ app = FastAPI(
 )
 
 # --- CONFIGURAÇÃO DO CORS ---
-# Definição das origens permitidas
-origins = [
-    "http://localhost:3000",  # Seu frontend Next.js rodando localmente para desenvolvimento
-    # Adicione aqui a URL do seu frontend quando fizer deploy na Vercel
-    # Ex: "https://seu-projeto-frontend.vercel.app"
-    # Adicione também "https://ai.agenciaml.com" se você planeja ter um frontend servido no mesmo domínio
-    # ou se outras aplicações nesse domínio precisarem acessar a API.
-    # Por segurança, seja o mais específico possível com as origens.
-]
+# Definição das origens permitidas a partir da configuração
+origins = [origin.strip() for origin in settings.ALLOWED_ORIGINS.split(',') if origin.strip()]
 
 # Inclusão do middleware CORS na aplicação
 app.add_middleware(


### PR DESCRIPTION
## Summary
- derive allowed CORS origins from `ALLOWED_ORIGINS` setting
- expose new `ALLOWED_ORIGINS` environment variable in settings
- document configuration options in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f55550374832da36a4d1d8abed635